### PR TITLE
Proxy code generation improvements, bugfixes

### DIFF
--- a/Publicizer.Tests/Data/ProxyTypes2.cs
+++ b/Publicizer.Tests/Data/ProxyTypes2.cs
@@ -1,0 +1,16 @@
+﻿using Publicizer.Annotation;
+using NamespaceForTypeWithPrivateMembers;
+
+// NOTE: embedded namespaces are intentional to test the code generation
+namespace Publicizer.Tests.Data
+{
+    [Publicize(typeof(TypeWithPrivateMembers))]
+    internal partial class InternalProxy
+    {
+    }
+
+    [Publicize(typeof(TypeWithPrivateMembers))]
+    public partial struct StructProxy
+    {
+    }
+}

--- a/Publicizer.Tests/Data/TypeWithPrivateMembers.cs
+++ b/Publicizer.Tests/Data/TypeWithPrivateMembers.cs
@@ -18,6 +18,14 @@ public class TypeWithPrivateMembers
     private int _readonlyProperty { get; }
     private int _property { get; set; }
 
+    public TypeWithPrivateMembers()
+    {
+    }
+
+    public TypeWithPrivateMembers(int dummy)
+    {
+    }
+
     private static void StaticProcedure()
     {
         StaticLogger.Log();


### PR DESCRIPTION
- does not generate forwarding for **constructors**
- does not generate **visibility modifier**, so users can define it freely
- considers whether the proxy type is a **`class`** or **`struct`**